### PR TITLE
Add support for 2nd argument to describe()

### DIFF
--- a/js2-imenu-mocha.el
+++ b/js2-imenu-mocha.el
@@ -159,9 +159,9 @@ NODE must be a function call."
 
 (defun js2-imenu-mocha--node-body (node)
   "Return a node corresponding to the body of a `describe' or `it' NODE."
-  (when-let ((second-arg (cadr (js2-call-node-args node))))
-    (when (js2-function-node-p second-arg)
-      (js2-function-node-body second-arg))))
+  (when-let ((last-arg (car (last (js2-call-node-args node)))))
+    (when (js2-function-node-p last-arg)
+      (js2-function-node-body last-arg))))
 
 (provide 'js2-imenu-mocha)
 ;;; js2-imenu-mocha.el ends here

--- a/test/js2-imenu-mocha-integration-test.el
+++ b/test/js2-imenu-mocha-integration-test.el
@@ -69,6 +69,17 @@
                     '(("describe top-level"
                        ("*declaration*" . 1))))))))
 
+(ert-deftest js2-imenu-mocha-integration-describe-with-argument ()
+  (js2-imenu-mocha-integration--create-js2-buffer
+   ("describe(\"top-level\", {}, () => {\n"
+    "it(\"test 1\", () => {});\n"
+    "})\n")
+   (let ((result (js2-imenu-mocha--generate-imenu-entries)))
+     (should (equal result
+                    '(("describe top-level"
+                       ("*declaration*" . 1)
+                       ("it test 1" . 35))))))))
+
 (ert-deftest js2-imenu-mocha-integration-fdescribe ()
   (js2-imenu-mocha-integration--create-js2-buffer
    ("fdescribe(\"top-level\", () => {})\n")


### PR DESCRIPTION
This is used by Cypress to specify test options:
https://docs.cypress.io/guides/references/configuration#Test-Configuration